### PR TITLE
fix: use dynamic imports with ssr:false in Navigation page to resolve…

### DIFF
--- a/src/app/Navigation/page.js
+++ b/src/app/Navigation/page.js
@@ -1,7 +1,9 @@
 "use client";
 import { useState } from "react";
-import History from "../Pages/History";
-import Whiteboard from "../Pages/Whiteboard";
+import dynamic from "next/dynamic";
+
+const History = dynamic(() => import("../Pages/History"), { ssr: false });
+const Whiteboard = dynamic(() => import("../Pages/Whiteboard"), { ssr: false });
 const Navigation = () => {
   const [navSelected, setNavSelected] = useState("Whiteboard");
   return (


### PR DESCRIPTION
… prerender errors

Prevents window is not defined and auth destructure TypeError during Vercel static generation by ensuring Whiteboard and History (and their transitive deps like framer-motion) are never loaded on the server.